### PR TITLE
Fix Hashtags test

### DIFF
--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -8,7 +8,7 @@ client = PublicClient()
 def test_suggested_hashtags():
     """Verifies we can extract suggested hashtags."""
     resp = list(client.hashtags(max=10))
-    assert len(resp) == 5 # max seems to be 5 now
+    assert len(resp) == 5  # max seems to be 5 now
 
     # Later results (e.g., past #5) won't have expanded info
     assert "hashtag" in resp[0]

--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -8,7 +8,7 @@ client = PublicClient()
 def test_suggested_hashtags():
     """Verifies we can extract suggested hashtags."""
     resp = list(client.hashtags(max=10))
-    assert len(resp) == 10
+    assert len(resp) == 5 # max seems to be 5 now
 
     # Later results (e.g., past #5) won't have expanded info
     assert "hashtag" in resp[0]


### PR DESCRIPTION
Now max length seems to be 5. What could be done to make tests more resilient to changes from their BE?