### PR TITLE
Misc. fixes

### DIFF
--- a/gogettr/capabilities/all.py
+++ b/gogettr/capabilities/all.py
@@ -104,8 +104,7 @@ class All(Capability):
         except GettrApiError as e:
             logging.warning("Hit API error while pulling: %s", e)
             return
-
-        if data["data"]["txt"] == "Content Not Found":
+        if "txt" in data and data["data"]["txt"] == "Content Not Found":
             # Yes, this is how they do it. It's just a string.
             logging.info("Post %s not found...", post_id)
             return

--- a/tests/test_user_info.py
+++ b/tests/test_user_info.py
@@ -13,7 +13,7 @@ def test_user_info():
     assert resp["nickname"] == "Support & Help"
     assert resp["username"] == "support"
     assert resp["ousername"] == "support"
-    assert resp["infl"] == 1
+    assert resp["infl"] == 2
 
 
 def test_user_info_nonexistent():


### PR DESCRIPTION
In light of issue #13 a change was made to the backend, now on some posts, the `txt` string key is not present in `data`.

<details>
<summary>sample of posts</summary>

```
{
	'data': {
		'udate': 1639344588908,
		'acl': {
			'_t': 'acl'
		},
		'_t': 'post',
		'cdate': 1639344588908,
		'_id': 'pew0',
		'nfound': True,
		'txt': 'Content Not Found'
	},
	'aux': None,
	'serial': 'post'
} {
	'data': {
		'udate': 1639344096311,
		'acl': {
			'_t': 'acl'
		},
		'_t': 'post',
		'cdate': 1639344588946,
		'_id': 'pew9',
		'vis': 'd'
	},
	'aux': None,
	'serial': 'post'
}

{
	'data': {
		'udate': 1639344588929,
		'acl': {
			'_t': 'acl'
		},
		'_t': 'post',
		'cdate': 1639344588929,
		'_id': 'pew3',
		'nfound': True,
		'txt': 'Content Not Found'
	},
	'aux': None,
	'serial': 'post'
} {
	'data': {
		'udate': 1625151531564,
		'acl': {
			'pub': 4
		},
		'_t': 'post',
		'cdate': 1625151530055,
		'_id': 'pew8',
		'txt': 'Himalaya',
		'imgs': ['null'],
		'vid_wid': '4032',
		'vid_hgt': '3024',
		'vis': 'p',
		'meta': [{
			'wid': None,
			'hgt': None,
			'meta': {
				'heads': None
			}
		}],
		'uid': 'milesmusk',
		'shbpst': 1
	},
	'aux': {
		'shrdpst': None,
		's_pst': {
			'shbpst': 1
		},
		'uinf': {
			'milesmusk': {
				'udate': '1625274241748',
				'_t': 'uinf',
				'_id': 'milesmusk',
				'nickname': '项羽',
				'username': 'milesmusk',
				'ousername': 'milesmusk',
				'dsc': 'Everything is just beginning',
				'status': 'a',
				'cdate': '1625149711910',
				'lang': 'en',
				'infl': 2,
				'ico': 'group37/getter/2021/07/03/01/1f4e2119-04a0-6827-35e8-1acf22e82b69/a628de634b82c0cec995da13db2874a9.jpg',
				'location': 'NFSC',
				'flw': '958',
				'flg': '1444',
				'lkspst': '1',
				'shspst': '1'
			}
		},
		'lks': [],
		'shrs': []
	},
	'serial': 'post'
}
```
</details>

Also the support account's `infl` key is now 2.
