### PR TITLE
Allow non-ASCII chars in CLI output by default, with flag to revert to original behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Options:
                            to first)
   --type [posts|comments]
   --workers INTEGER        the number of threads to run in parallel
-  --ensure_ascii           Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii           Ensure only ASCII output
   --help                   Show this message and exit.
 ```
 
@@ -129,7 +129,7 @@ Usage: gogettr comments [OPTIONS] POST_ID
 
 Options:
   --max INTEGER       the maximum number of comments to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -146,7 +146,7 @@ Usage: gogettr hashtags [OPTIONS]
 
 Options:
   --max INTEGER       the maximum number of hashtags to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -162,7 +162,7 @@ Usage: gogettr search [OPTIONS] QUERY
 
 Options:
   --max INTEGER       the maximum number of posts to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -175,7 +175,7 @@ Usage: gogettr suggested [OPTIONS]
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -189,7 +189,7 @@ Usage: gogettr trends [OPTIONS]
 Options:
   --max INTEGER       the maximum number of posts to pull
   --until TEXT        the ID of the earliest post to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -205,7 +205,7 @@ Options:
   --until TEXT                   the ID of the earliest activity to pull for
                                  the user
   --type [posts|comments|likes]
-  --ensure_ascii                 Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii                 Ensure only ASCII output
   --help                         Show this message and exit.
 ```
 
@@ -218,7 +218,7 @@ Usage: gogettr user-followers [OPTIONS] USERNAME
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -231,7 +231,7 @@ Usage: gogettr user-following [OPTIONS] USERNAME
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -243,7 +243,7 @@ Usage: gogettr user-info [OPTIONS] USERNAME
   Pull given user's information.
 
 Options:
-  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
+  --ensure_ascii      Ensure only ASCII output
   --help              Show this message and exit.
 ```
 
@@ -256,6 +256,7 @@ Usage: gogettr live [OPTIONS]
 
 Options:
   --max INTEGER  the maximum number of livestream entries to pull
+  --ensure_ascii Ensure only ASCII output
   --help         Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Options:
                            to first)
   --type [posts|comments]
   --workers INTEGER        the number of threads to run in parallel
-  --not_ensure_ascii       Allow for non-ASCII output
+  --ensure_ascii           Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help                   Show this message and exit.
 ```
 
@@ -128,7 +128,7 @@ Usage: gogettr comments [OPTIONS] POST_ID
 
 Options:
   --max INTEGER       the maximum number of comments to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -145,7 +145,7 @@ Usage: gogettr hashtags [OPTIONS]
 
 Options:
   --max INTEGER       the maximum number of hashtags to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -161,7 +161,7 @@ Usage: gogettr search [OPTIONS] QUERY
 
 Options:
   --max INTEGER       the maximum number of posts to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -174,7 +174,7 @@ Usage: gogettr suggested [OPTIONS]
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -188,7 +188,7 @@ Usage: gogettr trends [OPTIONS]
 Options:
   --max INTEGER       the maximum number of posts to pull
   --until TEXT        the ID of the earliest post to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -204,7 +204,7 @@ Options:
   --until TEXT                   the ID of the earliest activity to pull for
                                  the user
   --type [posts|comments|likes]
-  --not_ensure_ascii             Allow for non-ASCII output
+  --ensure_ascii                 Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help                         Show this message and exit.
 ```
 
@@ -217,7 +217,7 @@ Usage: gogettr user-followers [OPTIONS] USERNAME
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -230,7 +230,7 @@ Usage: gogettr user-following [OPTIONS] USERNAME
 
 Options:
   --max INTEGER       the maximum number of users to pull
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 
@@ -242,7 +242,7 @@ Usage: gogettr user-info [OPTIONS] USERNAME
   Pull given user's information.
 
 Options:
-  --not_ensure_ascii  Allow for non-ASCII output
+  --ensure_ascii      Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output
   --help              Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Options:
                            to first)
   --type [posts|comments]
   --workers INTEGER        the number of threads to run in parallel
+  --not_ensure_ascii       Allow for non-ASCII output
   --help                   Show this message and exit.
 ```
 
@@ -126,8 +127,9 @@ Usage: gogettr comments [OPTIONS] POST_ID
   Pull comments on a specific post.
 
 Options:
-  --max INTEGER  the maximum number of comments to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of comments to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `hashtags`
@@ -142,8 +144,9 @@ Usage: gogettr hashtags [OPTIONS]
   associated with them, later results do not.
 
 Options:
-  --max INTEGER  the maximum number of hashtags to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of hashtags to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `search`
@@ -157,8 +160,9 @@ Usage: gogettr search [OPTIONS] QUERY
   archiving all the posts that result.
 
 Options:
-  --max INTEGER  the maximum number of posts to pull
-  --help         Show this message and exit
+  --max INTEGER       the maximum number of posts to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `suggested`
@@ -169,8 +173,9 @@ Usage: gogettr suggested [OPTIONS]
   Pull the suggested users (users displayed on the home page).
 
 Options:
-  --max INTEGER  the maximum number of users to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of users to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `trends`
@@ -181,9 +186,10 @@ Usage: gogettr trends [OPTIONS]
   Pull all the trends (posts displayed on the home page).
 
 Options:
-  --max INTEGER  the maximum number of posts to pull
-  --until TEXT   the ID of the earliest post to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of posts to pull
+  --until TEXT        the ID of the earliest post to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `user`
@@ -198,6 +204,7 @@ Options:
   --until TEXT                   the ID of the earliest activity to pull for
                                  the user
   --type [posts|comments|likes]
+  --not_ensure_ascii             Allow for non-ASCII output
   --help                         Show this message and exit.
 ```
 
@@ -209,8 +216,9 @@ Usage: gogettr user-followers [OPTIONS] USERNAME
   Pull all a user's followers.
 
 Options:
-  --max INTEGER  the maximum number of users to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of users to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `user-following`
@@ -221,8 +229,9 @@ Usage: gogettr user-following [OPTIONS] USERNAME
   Pull all users a given user follows.
 
 Options:
-  --max INTEGER  the maximum number of users to pull
-  --help         Show this message and exit.
+  --max INTEGER       the maximum number of users to pull
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ### `user-info`
@@ -233,7 +242,8 @@ Usage: gogettr user-info [OPTIONS] USERNAME
   Pull given user's information.
 
 Options:
-  --help  Show this message and exit.
+  --not_ensure_ascii  Allow for non-ASCII output
+  --help              Show this message and exit.
 ```
 
 ## Module Usage

--- a/gogettr/api.py
+++ b/gogettr/api.py
@@ -39,11 +39,11 @@ class ApiClient:
             logger.warning(
                 "Unable to pull from API: %s. Waiting %s seconds before retrying (%s/%s)...",
                 issue,
-                4**tries,
+                4 ** tries,
                 tries,
                 retries,
             )
-            time.sleep(4**tries)
+            time.sleep(4 ** tries)
             errors.append(issue)
 
         while tries < retries:

--- a/gogettr/cli.py
+++ b/gogettr/cli.py
@@ -40,7 +40,7 @@ def cli():
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def user(
     username,
@@ -78,7 +78,7 @@ def user(
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def all(
     first=None,
@@ -115,7 +115,7 @@ def all(
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def user_info(username, ensure_ascii: bool = True):
     """Pull given user's information."""
@@ -129,7 +129,7 @@ def user_info(username, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def user_followers(username, max: int = None, ensure_ascii: bool = True):
     """Pull all a user's followers."""
@@ -144,7 +144,7 @@ def user_followers(username, max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def user_following(username, max: int = None, ensure_ascii: bool = True):
     """Pull all users a given user follows."""
@@ -159,7 +159,7 @@ def user_following(username, max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def trends(max: int = None, until: str = None, ensure_ascii: bool = True):
     """Pull all the trends (posts displayed on the home page)."""
@@ -173,7 +173,7 @@ def trends(max: int = None, until: str = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def suggested(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested users (users displayed on the home page)."""
@@ -187,7 +187,7 @@ def suggested(max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def hashtags(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested hashtags (the top suggestions are displayed on the
@@ -206,7 +206,7 @@ def hashtags(max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def search(query, max: int = None, ensure_ascii: bool = True):
     """Search posts for the given query.
@@ -226,7 +226,7 @@ def search(query, max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def comments(post_id: str, max: int = None, ensure_ascii: bool = True):
     """Pull comments on a specific post."""
@@ -242,7 +242,7 @@ def comments(post_id: str, max: int = None, ensure_ascii: bool = True):
     "--ensure_ascii",
     is_flag=True,
     default=False,
-    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
+    help="Ensure only ASCII output",
 )
 def live(max: int = None, ensure_ascii: bool = True):
     """Pull livestream posts."""

--- a/gogettr/cli.py
+++ b/gogettr/cli.py
@@ -136,7 +136,7 @@ def user_followers(username, max: int = None, ensure_ascii: bool = True):
     for user_dict in client.user_relationships(username, max=max, type="followers"):
         print(json.dumps(user_dict, ensure_ascii=ensure_ascii))
 
-
+# jscpd:ignore-start
 @cli.command()
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
@@ -146,6 +146,7 @@ def user_followers(username, max: int = None, ensure_ascii: bool = True):
     default=False,
     help="Ensure only ASCII output",
 )
+# jscpd:ignore-end
 def user_following(username, max: int = None, ensure_ascii: bool = True):
     """Pull all users a given user follows."""
     for user_dict in client.user_relationships(username, max=max, type="following"):

--- a/gogettr/cli.py
+++ b/gogettr/cli.py
@@ -37,7 +37,10 @@ def cli():
     default="posts",
 )
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def user(
     username,
@@ -72,7 +75,10 @@ def user(
     "--workers", help="the number of threads to run in parallel", type=int, default=10
 )
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def all(
     first=None,
@@ -106,7 +112,10 @@ def all(
 @cli.command()
 @click.argument("username")
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def user_info(username, ensure_ascii: bool = True):
     """Pull given user's information."""
@@ -117,7 +126,10 @@ def user_info(username, ensure_ascii: bool = True):
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def user_followers(username, max: int = None, ensure_ascii: bool = True):
     """Pull all a user's followers."""
@@ -129,7 +141,10 @@ def user_followers(username, max: int = None, ensure_ascii: bool = True):
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def user_following(username, max: int = None, ensure_ascii: bool = True):
     """Pull all users a given user follows."""
@@ -141,7 +156,10 @@ def user_following(username, max: int = None, ensure_ascii: bool = True):
 @click.option("--max", help="the maximum number of posts to pull", type=int)
 @click.option("--until", help="the ID of the earliest post to pull")
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def trends(max: int = None, until: str = None, ensure_ascii: bool = True):
     """Pull all the trends (posts displayed on the home page)."""
@@ -152,7 +170,10 @@ def trends(max: int = None, until: str = None, ensure_ascii: bool = True):
 @cli.command()
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def suggested(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested users (users displayed on the home page)."""
@@ -163,7 +184,10 @@ def suggested(max: int = None, ensure_ascii: bool = True):
 @cli.command()
 @click.option("--max", help="the maximum number of hashtags to pull", type=int)
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def hashtags(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested hashtags (the top suggestions are displayed on the
@@ -179,7 +203,10 @@ def hashtags(max: int = None, ensure_ascii: bool = True):
 @click.argument("query")
 @click.option("--max", help="the maximum number of posts to pull", type=int)
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def search(query, max: int = None, ensure_ascii: bool = True):
     """Search posts for the given query.
@@ -196,7 +223,10 @@ def search(query, max: int = None, ensure_ascii: bool = True):
 @click.option("--max", help="the maximum number of comments to pull", type=int)
 @click.argument("post_id")
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def comments(post_id: str, max: int = None, ensure_ascii: bool = True):
     """Pull comments on a specific post."""
@@ -209,7 +239,10 @@ def comments(post_id: str, max: int = None, ensure_ascii: bool = True):
     "--max", help="the maximum number of livestream entries to pull", type=int
 )
 @click.option(
-    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
+    "--ensure_ascii",
+    is_flag=True,
+    default=False,
+    help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output",
 )
 def live(max: int = None, ensure_ascii: bool = True):
     """Pull livestream posts."""

--- a/gogettr/cli.py
+++ b/gogettr/cli.py
@@ -37,18 +37,18 @@ def cli():
     default="posts",
 )
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
 def user(
     username,
     max: int = None,
     until: str = None,
     type: str = None,
-    not_ensure_ascii: bool = True,
+    ensure_ascii: bool = True,
 ):
     """Pull the posts, likes, or comments made by a user."""
     for post in client.user_activity(username, max=max, until=until, type=type):
-        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(post, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
@@ -72,7 +72,7 @@ def user(
     "--workers", help="the number of threads to run in parallel", type=int, default=10
 )
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
 def all(
     first=None,
@@ -81,7 +81,7 @@ def all(
     rev=False,
     type: str = None,
     workers: int = None,
-    not_ensure_ascii: bool = True,
+    ensure_ascii: bool = True,
 ):
     """Pull all posts (or comments) sequentially.
 
@@ -100,103 +100,103 @@ def all(
         type=type,
         workers=workers,
     ):
-        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(post, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def user_info(username, not_ensure_ascii: bool = True):
+def user_info(username, ensure_ascii: bool = True):
     """Pull given user's information."""
-    print(json.dumps(client.user_info(username), ensure_ascii=not_ensure_ascii))
+    print(json.dumps(client.user_info(username), ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def user_followers(username, max: int = None, not_ensure_ascii: bool = True):
+def user_followers(username, max: int = None, ensure_ascii: bool = True):
     """Pull all a user's followers."""
     for user_dict in client.user_relationships(username, max=max, type="followers"):
-        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(user_dict, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def user_following(username, max: int = None, not_ensure_ascii: bool = True):
+def user_following(username, max: int = None, ensure_ascii: bool = True):
     """Pull all users a given user follows."""
     for user_dict in client.user_relationships(username, max=max, type="following"):
-        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(user_dict, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of posts to pull", type=int)
 @click.option("--until", help="the ID of the earliest post to pull")
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def trends(max: int = None, until: str = None, not_ensure_ascii: bool = True):
+def trends(max: int = None, until: str = None, ensure_ascii: bool = True):
     """Pull all the trends (posts displayed on the home page)."""
     for post in client.trends(max=max, until=until):
-        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(post, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of users to pull", type=int)
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def suggested(max: int = None, not_ensure_ascii: bool = True):
+def suggested(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested users (users displayed on the home page)."""
     for user_dict in client.suggested(max=max):
-        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(user_dict, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of hashtags to pull", type=int)
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def hashtags(max: int = None, not_ensure_ascii: bool = True):
+def hashtags(max: int = None, ensure_ascii: bool = True):
     """Pull the suggested hashtags (the top suggestions are displayed on the
     front page).
 
     Note that while the first five or so hashtags have expanded information
     associated with them, later results do not."""
     for hashtag in client.hashtags(max=max):
-        print(json.dumps(hashtag, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(hashtag, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.argument("query")
 @click.option("--max", help="the maximum number of posts to pull", type=int)
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def search(query, max: int = None, not_ensure_ascii: bool = True):
+def search(query, max: int = None, ensure_ascii: bool = True):
     """Search posts for the given query.
 
     This is equivalent to putting the query in the GETTR search box and
     archiving all the posts that result."""
     for post in client.search(query, max=max):
-        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(post, ensure_ascii=ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of comments to pull", type=int)
 @click.argument("post_id")
 @click.option(
-    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+    "--ensure_ascii", is_flag=True, default=False, help="Sets the output to only allow ASCII characters, it is an optional flag, by default it will not ensure ASCII char output"
 )
-def comments(post_id: str, max: int = None, not_ensure_ascii: bool = True):
+def comments(post_id: str, max: int = None, ensure_ascii: bool = True):
     """Pull comments on a specific post."""
     for comment in client.comments(post_id=post_id, max=max):
-        print(json.dumps(comment, ensure_ascii=not_ensure_ascii))
+        print(json.dumps(comment, ensure_ascii=ensure_ascii))

--- a/gogettr/cli.py
+++ b/gogettr/cli.py
@@ -36,10 +36,19 @@ def cli():
     type=click.Choice(["posts", "comments", "likes"]),
     default="posts",
 )
-def user(username, max: int = None, until: str = None, type: str = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def user(
+    username,
+    max: int = None,
+    until: str = None,
+    type: str = None,
+    not_ensure_ascii: bool = True,
+):
     """Pull the posts, likes, or comments made by a user."""
     for post in client.user_activity(username, max=max, until=until, type=type):
-        print(json.dumps(post))
+        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
@@ -62,6 +71,9 @@ def user(username, max: int = None, until: str = None, type: str = None):
 @click.option(
     "--workers", help="the number of threads to run in parallel", type=int, default=10
 )
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
 def all(
     first=None,
     last=None,
@@ -69,6 +81,7 @@ def all(
     rev=False,
     type: str = None,
     workers: int = None,
+    not_ensure_ascii: bool = True,
 ):
     """Pull all posts (or comments) sequentially.
 
@@ -87,79 +100,103 @@ def all(
         type=type,
         workers=workers,
     ):
-        print(json.dumps(post))
+        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
-def user_info(username):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def user_info(username, not_ensure_ascii: bool = True):
     """Pull given user's information."""
-    print(json.dumps(client.user_info(username)))
+    print(json.dumps(client.user_info(username), ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
-def user_followers(username, max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def user_followers(username, max: int = None, not_ensure_ascii: bool = True):
     """Pull all a user's followers."""
     for user_dict in client.user_relationships(username, max=max, type="followers"):
-        print(json.dumps(user_dict))
+        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.argument("username")
 @click.option("--max", help="the maximum number of users to pull", type=int)
-def user_following(username, max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def user_following(username, max: int = None, not_ensure_ascii: bool = True):
     """Pull all users a given user follows."""
     for user_dict in client.user_relationships(username, max=max, type="following"):
-        print(json.dumps(user_dict))
+        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of posts to pull", type=int)
 @click.option("--until", help="the ID of the earliest post to pull")
-def trends(max: int = None, until: str = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def trends(max: int = None, until: str = None, not_ensure_ascii: bool = True):
     """Pull all the trends (posts displayed on the home page)."""
     for post in client.trends(max=max, until=until):
-        print(json.dumps(post))
+        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of users to pull", type=int)
-def suggested(max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def suggested(max: int = None, not_ensure_ascii: bool = True):
     """Pull the suggested users (users displayed on the home page)."""
     for user_dict in client.suggested(max=max):
-        print(json.dumps(user_dict))
+        print(json.dumps(user_dict, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of hashtags to pull", type=int)
-def hashtags(max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def hashtags(max: int = None, not_ensure_ascii: bool = True):
     """Pull the suggested hashtags (the top suggestions are displayed on the
     front page).
 
     Note that while the first five or so hashtags have expanded information
     associated with them, later results do not."""
     for hashtag in client.hashtags(max=max):
-        print(json.dumps(hashtag))
+        print(json.dumps(hashtag, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.argument("query")
 @click.option("--max", help="the maximum number of posts to pull", type=int)
-def search(query, max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def search(query, max: int = None, not_ensure_ascii: bool = True):
     """Search posts for the given query.
 
     This is equivalent to putting the query in the GETTR search box and
     archiving all the posts that result."""
     for post in client.search(query, max=max):
-        print(json.dumps(post))
+        print(json.dumps(post, ensure_ascii=not_ensure_ascii))
 
 
 @cli.command()
 @click.option("--max", help="the maximum number of comments to pull", type=int)
 @click.argument("post_id")
-def comments(post_id: str, max: int = None):
+@click.option(
+    "--not_ensure_ascii", is_flag=True, default=True, help="Allow for non-ASCII output"
+)
+def comments(post_id: str, max: int = None, not_ensure_ascii: bool = True):
     """Pull comments on a specific post."""
     for comment in client.comments(post_id=post_id, max=max):
-        print(json.dumps(comment))
+        print(json.dumps(comment, ensure_ascii=not_ensure_ascii))


### PR DESCRIPTION
As discussed here: https://github.com/stanfordio/gogettr/issues/7

- The `ensure_ascii` flag for `JSON dumps` is now False by default
- it can be overridden via command line boolean flag `--ensure_ascii`

![imagen](https://user-images.githubusercontent.com/5891284/175558388-b913cdc6-0d08-4a53-912a-573d6bfab117.png)
